### PR TITLE
flush ip6tables in almalinux 8

### DIFF
--- a/files/internals/functions.apf
+++ b/files/internals/functions.apf
@@ -64,7 +64,7 @@ modinit() {
         # Loading Kernel Modules
         ml ip_tables 1
  fi
-	modlist="ip_conntrack ip_conntrack_ftp ip_conntrack_irc iptable_filter iptable_mangle ipt_ecn ipt_length ipt_limit ipt_LOG ipt_mac ipt_multiport ipt_owner ipt_recent ipt_REJECT ipt_state ipt_TCPMSS ipt_TOS ipt_ttl ipt_ULOG nf_conntrack nf_conntrack_ftp nf_conntrack_irc xt_conntrack xt_conntrack_ftp xt_conntrack_irc xt_ecn xt_length xt_limit xt_LOG xt_mac xt_multiport xt_owner xt_recent xt_REJECT xt_state xt_TCPMSS xt_TOS xt_ttl xt_ULOG iptable_nat"
+	modlist="ip_conntrack ip_conntrack_ftp ip_conntrack_irc iptable_filter iptable_mangle ipt_ecn ipt_length ipt_limit ipt_LOG ipt_mac ipt_multiport ipt_owner ipt_recent ipt_REJECT ipt_state ipt_TCPMSS ipt_TOS ipt_ttl ipt_ULOG nf_conntrack nf_conntrack_ftp nf_conntrack_irc xt_conntrack xt_conntrack_ftp xt_conntrack_irc xt_ecn xt_length xt_limit xt_LOG xt_mac xt_multiport xt_owner xt_recent xt_REJECT xt_state xt_TCPMSS xt_TOS xt_ttl xt_ULOG iptable_nat ip6_tables"
 	for mod in $modlist; do
 		ml $mod
 	done
@@ -244,6 +244,9 @@ $IPT $IPT_FLAGS -P FORWARD ACCEPT
 
 if [ "$USE_IPV6" == "1" ]; then
 	chains6=`cat /proc/net/ip6_tables_names 2>/dev/null`
+	if [ -z "$chain6" ] && [ -x "$NFT" ] ; then
+	   chains6="`$NFT list tables ip6 | awk '{print $3}'`"
+	fi
 	for i in $chains6; do $IP6T -t $i -F; done
 	for i in $chains6; do $IP6T -t $i -X; done
 	$IP6T -P INPUT ACCEPT

--- a/files/internals/internals.conf
+++ b/files/internals/internals.conf
@@ -20,6 +20,7 @@ DIFF=`which diff 2> /dev/null`
 WGET=`which wget 2> /dev/null`
 MD5=`which md5sum 2> /dev/null`
 UNAME=`which uname 2> /dev/null`
+NFT=`which nft 2> /dev/null`
 
 ## Force MONOKERN option on Virtuozzo/OpenVZ based VPS
 if [ -d /proc/vz -a ! -d /proc/bc ]; then


### PR DESCRIPTION
in almalinux8, ip6_tables is not loaded, so load now. but even if ti loaded, in almalinux8, it is empty, so now check if NFT is executable, try to list chains via nft api